### PR TITLE
fix bugs

### DIFF
--- a/jmqtt-common/src/main/java/org/jmqtt/common/helper/MixAll.java
+++ b/jmqtt-common/src/main/java/org/jmqtt/common/helper/MixAll.java
@@ -17,7 +17,7 @@ import java.util.zip.InflaterInputStream;
 
 public class MixAll {
 
-    public static String MQTT_VERSION_SUPPORT = "mqtt, mqtt3.1, mqtt3.1.1";
+    public static String MQTT_VERSION_SUPPORT = "mqtt, mqttv3.1, mqttv3.1.1";
 
     public static boolean createIfNotExistsDir(File file){
         return file != null && (file.exists() ? file.isDirectory() : file.mkdirs());

--- a/jmqtt-group/src/main/java/org/jmqtt/group/processor/ClusterOuterAPI.java
+++ b/jmqtt-group/src/main/java/org/jmqtt/group/processor/ClusterOuterAPI.java
@@ -30,7 +30,7 @@ public class ClusterOuterAPI {
     private long timeoutMillis;
     private static final int NODE_ACTIVE_TIME_MILLIS = 30000;
 
-    public ClusterOuterAPI(ClusterConfig clusterConfigs, ClusterRemotingClient clusterRemotingClient) {
+    public ClusterOuterAPI(ClusterConfig clusterConfig, ClusterRemotingClient clusterRemotingClient) {
         this.clusterConfig = clusterConfig;
         this.clusterRemotingClient = clusterRemotingClient;
         this.scheduleRegisterNode = new ScheduledThreadPoolExecutor(1, new ThreadFactoryImpl("scheduleRegisterNodeThread"));


### PR DESCRIPTION
1. group version start bug: null pointer
at org.jmqtt.group.processor.ClusterOuterAPI.<init>(ClusterOuterAPI.java:38)
-> wrong var name
2. websocket connection bug
java.io.ioexception: websocket response header:empty sec-websocket-protocol
->Sec-WebSocket-Protocol should be mqttv3.1,mqttv3.1.1 , not mqtt3.1,mqtt3.1.1